### PR TITLE
New feature: Change the aspect ratio of the cropping area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,7 @@
 ## 0.0.2 - 2021/05/16
 
 -   Added `ImageCrop#get_cropped_bounds(): IBounds | null` for getting the current selection bounds
+
+## 0.1 - 2023/10/07
+
+-   Added the possibility to pass a ratio to be applied

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ See a demo at [novacbn.github.io/svelte-image-crop/demo](https://novacbn.github.
 <!--
     NOTE: We need to bind to the `ImageCrop` instance to access its methods
 -->
-<ImageCrop bind:this={image_crop} {src} on:state={on_state} />
+<ImageCrop bind:this={image_crop} {src} on:state={on_state} ratio={false} />
 
 <button
     disabled={src === DEFAULT_IMAGE_SRC}
@@ -136,9 +136,10 @@ npm install github:novacbn/svelte-image-crop
 
 ### Properties
 
-| Signature     | Default | Description                                      |
-| ------------- | ------- | ------------------------------------------------ |
-| `src: string` | `""`    | Sets the image to be loaded into the crop editor |
+| Signature               | Default | Description                                                  |
+| ----------------------- | ------- | ------------------------------------------------------------ |
+| `src: string`           | `""`    | Sets the image to be loaded into the crop editor             |
+| `ratio: boolean|number` | `false` | Aspect of the cropping area. The value is the ratio between its width and its height. The default value is `false`, that means by default, no ratio is used. Examples for ratios:  `(9/16)`, `(3/4)` |
 
 ### Methods
 

--- a/README.md
+++ b/README.md
@@ -136,10 +136,10 @@ npm install github:novacbn/svelte-image-crop
 
 ### Properties
 
-| Signature               | Default | Description                                                  |
-| ----------------------- | ------- | ------------------------------------------------------------ |
-| `src: string`           | `""`    | Sets the image to be loaded into the crop editor             |
-| `ratio: boolean|number` | `false` | Aspect of the cropping area. The value is the ratio between its width and its height. The default value is `false`, that means by default, no ratio is used. Examples for ratios:  `(9/16)`, `(3/4)` |
+| Signature                 | Default | Description                                                  |
+| ------------------------- | ------- | ------------------------------------------------------------ |
+| `src: string`             | `""`    | Sets the image to be loaded into the crop editor             |
+| `ratio: boolean ∨ number` | `false` | Aspect of the cropping area. The value is the ratio between its width and its height. The default value is `false`, that means by default, no ratio is used. Examples for ratios:  `(9/16)`, `(3/4)` |
 
 ### Methods
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "@novacbn/svelte-image-crop",
     "description": "Simple click'n'drag Image Cropping using Web APIs",
     "author": "novacbn",
-    "version": "0.0.2",
+    "version": "0.1",
     "keywords": [
         "image-crop",
         "svelte",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "@novacbn/svelte-image-crop",
     "description": "Simple click'n'drag Image Cropping using Web APIs",
     "author": "novacbn",
-    "version": "0.1",
+    "version": "0.1.0",
     "keywords": [
         "image-crop",
         "svelte",

--- a/src/components/ImageCrop.svelte
+++ b/src/components/ImageCrop.svelte
@@ -91,6 +91,7 @@
      * @type {string}
      */
     export let src;
+    export let ratio = false;
 
     function on_end() {
         is_dragging = false;
@@ -157,7 +158,7 @@
     let _rect;
     $: {
         const old_rect = _rect;
-        _rect = _is_cropping ? get_rect(position_start, position_end) : null;
+        _rect = _is_cropping ? get_rect(position_start, position_end, ratio) : null;
 
         if (
             typeof old_rect !== typeof _rect ||
@@ -187,10 +188,9 @@
                 height: image_element.naturalHeight,
             };
 
-            _image_bounds = get_bounds(
-                get_relative_point(from, to, position_start),
-                get_relative_point(from, to, position_end)
-            );
+            let _rect_relative = get_rect(get_relative_point(from, to, position_start), get_relative_point(from, to, position_end), ratio)
+            _image_bounds = get_bounds(_rect_relative);
+
         } else _image_bounds = null;
     }
 
@@ -224,10 +224,10 @@
 </script>
 
 <div
-    class="image-crop"
-    data-cropping={_is_cropping ? true : undefined}
-    data-dragging={is_dragging ? true : undefined}
-    style={_max_height}
+        class="image-crop"
+        data-cropping={_is_cropping ? true : undefined}
+        data-dragging={is_dragging ? true : undefined}
+        style={_max_height}
 >
     <img bind:this={image_element} class="image-crop-background" {src} />
 

--- a/src/util/math.js
+++ b/src/util/math.js
@@ -29,16 +29,14 @@
  * @property {number} right
  * @property {number} top
  */
-
 /**
- * Returns the bounding box of two points or a rectangle in 2D space 
- * 
- * @param {IPoint | IRect} rect 
- * @param {IPoint} [end] 
+ * Returns the bounding box of two points or a rectangle in 2D space
+ *
+ * @param {IPoint | IRect} rect
  * @returns {IBounds}
  */
-export function get_bounds(rect, end) {
-    const {left, right, top, bottom} = end ? get_rect(rect, end) : (rect);
+export function get_bounds(rect) {
+    const {left, right, top, bottom} = (rect);
 
     return {
         x: left,
@@ -50,19 +48,32 @@ export function get_bounds(rect, end) {
 }
 
 /**
- * Returns the rectangle corners of two points in 2D space
- * 
+ * Returns the rectangle corners of two points in 2D space, optionally applying a ratio
+ *
  * @param {IPoint} start
  * @param {IPoint} end
+ * @param {number} ratio - The ratio of the cropped area, will be only applied if the ratio is not false
  * @returns {IRect}
  */
-export function get_rect(start, end) {
+export function get_rect(start, end, ratio) {
     const {x: start_x, y: start_y} = start;
     const {x: end_x, y: end_y} = end;
 
+    let left, right;
+    if (ratio) {
+        let height = Math.max(start_y, end_y) - Math.min(start_y, end_y)
+        let width = ratio * height
+
+        left = (start_x < end_x) ? start_x : start_x - width;
+        right = left + width;
+    } else {
+        left = Math.min(start_x, end_x);
+        right = Math.max(start_x, end_x)
+    }
+
     return {
-        left: Math.min(start_x, end_x),
-        right: Math.max(start_x, end_x),
+        left: left,
+        right: right,
 
         top: Math.min(start_y, end_y),
         bottom: Math.max(start_y, end_y),
@@ -71,7 +82,7 @@ export function get_rect(start, end) {
 
 /**
  * Returns and translates a point from one pair dimensions to another pair in 2D space
- * 
+ *
  * @param {IDimensions} from
  * @param {IDimensions} to
  * @param {IPoint} point


### PR DESCRIPTION
Possibility to change the aspect ratio of the cropping area. The value is the ratio between its width and its height. The default value is false, that means by default, no ratio is used (and thus, the default behaviour is applied). Examples for ratios: (9/16), (3/4)